### PR TITLE
update ranger's masking policy

### DIFF
--- a/agents-common/src/main/resources/service-defs/ranger-servicedef-starrocks.json
+++ b/agents-common/src/main/resources/service-defs/ranger-servicedef-starrocks.json
@@ -606,46 +606,32 @@
       },
       {
         "itemId": 2,
-        "name": "MASK_SHOW_LAST_4",
-        "label": "Partial mask: show last 4",
-        "description": "Show last 4 characters; replace rest with 'X'",
-        "transformer": "cast(regexp_replace({col}, '(.*)(.{4}$)', x -> regexp_replace(x[1], '.', 'X') || x[2]) as {type})"
-      },
-      {
-        "itemId": 3,
-        "name": "MASK_SHOW_FIRST_4",
-        "label": "Partial mask: show first 4",
-        "description": "Show first 4 characters; replace rest with 'x'",
-        "transformer": "cast(regexp_replace({col}, '(^.{4})(.*)', x -> x[1] || regexp_replace(x[2], '.', 'X')) as {type})"
-      },
-      {
-        "itemId": 4,
         "name": "MASK_HASH",
         "label": "Hash",
         "description": "Hash the value of a varchar with sha256",
-        "transformer": "cast(to_hex(sha256(to_utf8({col}))) as {type})"
+        "transformer": "cast((hex(sha2(from_binary(to_binary({COL}, 'utf8'), 'utf8'), 256))) AS {type})"
       },
       {
-        "itemId": 5,
+        "itemId": 3,
         "name": "MASK_NULL",
         "label": "Nullify",
         "description": "Replace with NULL"
       },
       {
-        "itemId": 6,
+        "itemId": 4,
         "name": "MASK_NONE",
         "label": "Unmasked (retain original value)",
         "description": "No masking"
       },
       {
-        "itemId": 12,
+        "itemId": 5,
         "name": "MASK_DATE_SHOW_YEAR",
         "label": "Date: show only year",
         "description": "Date: show only year",
         "transformer": "date_trunc('year', {col})"
       },
       {
-        "itemId": 13,
+        "itemId": 6,
         "name": "CUSTOM",
         "label": "Custom",
         "description": "Custom"


### PR DESCRIPTION
## What changes were proposed in this pull request?

in old json files, the masking policy use some functions that sr doesn't support or has different names. This pr fixed those issues.

Signed-off-by: wangsimo0 <[wangsimo418@gmail.com](mailto:wangsimo418@gmail.com)>
